### PR TITLE
Changed button icons to use Silverstripe button markup

### DIFF
--- a/css/cms-actions.css
+++ b/css/cms-actions.css
@@ -44,11 +44,6 @@ table .btn-link {
     margin-right: 5px;
 }
 
-/* Icons might need some help */
-.btn span.font-icon {
-    vertical-align: -0.125em;
-}
-
 /* Progressive actions */
 .progressive-action {
     position: relative;

--- a/src/CmsInlineFormAction.php
+++ b/src/CmsInlineFormAction.php
@@ -85,6 +85,11 @@ class CmsInlineFormAction extends LiteralField
 
     public function FieldHolder($properties = array())
     {
+        $classes = $this->extraClass();
+        if($this->buttonIcon) {
+            $classes .= " font-icon";
+            $classes .= ' font-icon-'.$this->buttonIcon;
+        }
         $link = $this->getLink();
         $attrs = '';
         if ($this->newWindow) {
@@ -93,11 +98,8 @@ class CmsInlineFormAction extends LiteralField
         if ($this->readonly) {
             $attrs .= ' style="display:none"';
         }
-        $content = '<a href="' . $link . '" class="btn ' . $this->extraClass() . ' action no-ajax"' . $attrs . '>';
+        $content = '<a href="' . $link . '" class="btn ' . $classes . ' action no-ajax"' . $attrs . '>';
         $title = $this->content;
-        if ($this->buttonIcon) {
-            $title = '<span class="font-icon font-icon-' . $this->buttonIcon . '"></span> ' . $title;
-        }
         $content .= $title;
         $content .= '</a>';
         $this->content = $content;

--- a/src/CustomAction.php
+++ b/src/CustomAction.php
@@ -49,7 +49,8 @@ class CustomAction extends FormAction
     public function Field($properties = array())
     {
         if ($this->buttonIcon) {
-            $this->buttonContent = $this->getButtonTitle();
+            $this->addExtraClass('font-icon');
+            $this->addExtraClass('font-icon-'.$this->buttonIcon);
         }
         // Note: type should stay "action" to properly submit
         $this->addExtraClass('custom-action');

--- a/src/CustomButton.php
+++ b/src/CustomButton.php
@@ -77,9 +77,6 @@ trait CustomButton
     protected function getButtonTitle()
     {
         $title = $this->title;
-        if ($this->buttonIcon) {
-            $title = '<span class="font-icon font-icon-' . $this->buttonIcon . '"></span> ' . $title;
-        }
         return $title;
     }
 

--- a/src/CustomLink.php
+++ b/src/CustomLink.php
@@ -63,6 +63,11 @@ class CustomLink extends LiteralField
             $classes .= ' no-ajax';
         }
 
+        if($this->buttonIcon) {
+            $classes .= " font-icon";
+            $classes .= ' font-icon-'.$this->buttonIcon;
+        }
+
         $attrs = '';
 
         // note: links with target are never submitted through ajax


### PR DESCRIPTION
It seems that rather than adding the button icon classes to a `span` within the button itself, Silverstripe adds the icon classes directly to the button itself, via `extraClasses`. So I have updated the module to do the same so that button icons now display consistently with other icons in the CMS.

I've tested this on `CustomAction`, `CustomLink` and `CmsInlineFormAction`.

**Before:**
<img width="515" alt="Screenshot 2021-08-30 at 16 27 19@2x" src="https://user-images.githubusercontent.com/329880/131364520-2ada6640-64e6-4c14-90d1-2a0d973db01e.png">

**After:**
<img width="525" alt="Screenshot 2021-08-30 at 16 29 30@2x" src="https://user-images.githubusercontent.com/329880/131364537-78496f6f-cc06-4af1-8c93-a6e846ad3c21.png">

Fixes #4 