### PR TITLE
fix: resolve conflict with Versioning and fix SS bug

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,0 +1,3 @@
+<?php
+
+\SilverStripe\Forms\GridField\GridFieldDetailForm::remove_extension('SilverStripe\\Versioned\\VersionedGridFieldDetailForm');

--- a/_config/cms-actions.yml
+++ b/_config/cms-actions.yml
@@ -1,5 +1,6 @@
 ---
 Name: cms-actions
+After: '#versionedgridfield'
 ---
 SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest:
   extensions:

--- a/src/ActionsGridFieldItemRequest.php
+++ b/src/ActionsGridFieldItemRequest.php
@@ -102,6 +102,10 @@ class ActionsGridFieldItemRequest extends DataExtension
         // We get the actions as defined on our record
         $CMSActions = $record->getCMSActions();
 
+        // address Silverstripe bug when SiteTree buttons are broken
+        // @link https://github.com/silverstripe/silverstripe-cms/issues/2702
+        $CMSActions->setForm($form);
+
         // We can the actions from the GridFieldDetailForm_ItemRequest
         // It sets the Save and Delete buttons + Right Group
         $actions = $form->Actions();


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-cms/issues/2702

When creating a ModelAdmin for a SiteTree, another SilverStripe plugin comes to action - `silverstripe/versioned` that has similar functionality thus duplicating the buttons.

Additionally, SiteTree::getCMSActions() produces broken "unpublish" button, which `silverstripe/versioned` fixes by doing `$CMSActions->setForm($form);` but this plugin doesn't (and it's not supposed to, but apparently it has to).

Here's the code to fix that:
* it disables the duplicating part of `silverstripe/versioned`
* it fixes the settings of buttons that come from SiteTree::getCMSActions