### PR TITLE
fix: delay drop-up to avoid duplication when working with SiteTree

### DIFF
--- a/src/ActionsGridFieldItemRequest.php
+++ b/src/ActionsGridFieldItemRequest.php
@@ -115,20 +115,14 @@ class ActionsGridFieldItemRequest extends DataExtension
             $MajorActions = $actions;
         }
 
-        // The Drop-up container may already exist
-        $dropUpContainer = $actions->fieldByName('ActionMenus.MoreOptions');
-
         // Push our actions that are otherwise ignored by SilverStripe
         foreach ($CMSActions as $action) {
-            if ($action instanceof CustomAction && $action->getDropUp()) {
-                if (!$dropUpContainer) {
-                    $dropUpContainer = $this->createDropUpContainer($actions);
-                }
-                $dropUpContainer->push($action);
-            } else {
-                $actions->push($action);
-            }
+            $actions->push($action);
         }
+
+        // We create a Drop-Up menu afterwards because it may already exist in the $CMSActions
+        // and we don't want to duplicate it
+        $this->processDropUpMenu($actions);
 
         // Add extension hook
         $record->extend('onBeforeUpdateCMSActions', $actions);
@@ -163,6 +157,27 @@ class ActionsGridFieldItemRequest extends DataExtension
 
         // Add extension hook
         $record->extend('onAfterUpdateCMSActions', $actions);
+    }
+
+
+    /**
+     * Collect all Drop-Up actions into a menu.
+     * @param FieldList $actions
+     * @return void
+     */
+    protected function processDropUpMenu($actions)
+    {
+        // The Drop-up container may already exist
+        $dropUpContainer = $actions->fieldByName('ActionMenus.MoreOptions');
+        foreach ($actions as $action) {
+            if ($action->hasMethod('getDropUp') && $action->getDropUp()) {
+                if (!$dropUpContainer) {
+                    $dropUpContainer = $this->createDropUpContainer($actions);
+                }
+                $action->getContainerFieldList()->removeByName($action->getName());
+                $dropUpContainer->push($action);
+            }
+        }
     }
 
     /**

--- a/src/CustomButton.php
+++ b/src/CustomButton.php
@@ -58,7 +58,7 @@ trait CustomButton
     }
 
     /**
-     * Get the dropUp malue
+     * Get the dropUp value
      * Called by ActionsGridFieldItemRequest to determine placement
      *
      * @return bool


### PR DESCRIPTION
SiteTree, for instance, provides it's own DropUp menu and without this patch it is duplicated. It still works, but we have two menus :)

Additionally, changed the way to detect if `isDropUp` method is available - to let other types of inputs to use it (i.e. `lekoala/silverstripe-pure-modal`).