### PR TITLE
Make GridFieldRowButton slightly more flexible

### DIFF
--- a/css/cms-actions.css
+++ b/css/cms-actions.css
@@ -67,3 +67,8 @@ table .btn-link {
 #ActionMenus {
     margin-left: 10px;
 }
+
+/* GridFieldRowButtons */
+.action.btn {
+    margin-top: -0.4rem;
+}


### PR DESCRIPTION
Because of a change to method signature of `getButtonLabel()`, merging this PR would require a version bump under semantic versioning.

FIX #16 