### PR TITLE
FIX: Find CompositeField actions

### DIFF
--- a/src/ActionsGridFieldItemRequest.php
+++ b/src/ActionsGridFieldItemRequest.php
@@ -400,6 +400,28 @@ class ActionsGridFieldItemRequest extends DataExtension
         return 'btn-primary';
     }
 
+    protected static function findAction($action, $definedActions)
+    {
+        $result = null;
+
+        foreach ($definedActions as $definedAction) {
+            if(is_a($definedAction, \SilverStripe\Forms\CompositeField::class)) {
+                $result = self::findAction($action, $definedAction->FieldList());
+            }
+
+            $definedActionName = $definedAction->getName();
+
+            if ($definedAction->hasMethod('actionName')) {
+                $definedActionName = $definedAction->actionName();
+            }
+            if ($definedActionName == $action) {
+                $result = $definedAction;
+            }
+        }
+
+        return $result;
+    }
+    
     /**
      * Forward a given action to a DataObject
      *
@@ -436,15 +458,7 @@ class ActionsGridFieldItemRequest extends DataExtension
         // Check if the action is indeed available
         $clickedAction = null;
         if (!empty($definedActions)) {
-            foreach ($definedActions as $definedAction) {
-                $definedActionName = $definedAction->getName();
-                if ($definedAction->hasMethod('actionName')) {
-                    $definedActionName = $definedAction->actionName();
-                }
-                if ($definedActionName == $action) {
-                    $clickedAction = $definedAction;
-                }
-            }
+            $clickedAction = self::findAction($action, $definedActions);
         }
         if (!$clickedAction) {
             $class = get_class($record);


### PR DESCRIPTION
Without recursive search for Actions this code block won't work:

```
 public function getCMSActions()
 {
        $actions = parent::getCMSActions();

        $actions->addFieldsToTab('ActionMenus.MoreOptions', [
            CustomAction::create('doCreateDefaultElements', 'Create Default Blocks'),
        ]);

        return $actions;
}

```

So you won't be able to add an action to submenu
![Screenshot from 2022-09-05 10-24-06](https://user-images.githubusercontent.com/672794/188403616-73f52011-d0ce-4c44-bf94-4112228dbc7f.png)
