### PR TITLE
Don't pop when the last param is an ID

### DIFF
--- a/src/DefaultLink.php
+++ b/src/DefaultLink.php
@@ -48,7 +48,10 @@ trait DefaultLink
         $dirParts = array_slice($dirParts, 3);
 
         // replace the current action
-        array_pop($dirParts);
+        if (!is_numeric(end($dirParts))) {
+            array_pop($dirParts);
+        }
+
         $dirParts[] = 'doCustomLink';
     
         $action = implode('/', $dirParts);


### PR DESCRIPTION
There was one situation i overlooked with the last commit. Sometimes the last param can be a ID instead of the action.
This PR checks if the last param is not numeric before pop'ing.