### PR TITLE
fix: revert changes to the actions display logic

### DIFF
--- a/src/ActionsGridFieldItemRequest.php
+++ b/src/ActionsGridFieldItemRequest.php
@@ -103,7 +103,10 @@ class ActionsGridFieldItemRequest extends DataExtension
 
         /** @var DataObject $record */
         $record = $itemRequest->record;
-        if (!$this->checkCan($record)) {
+        if (!$record) {
+            $record = $form->getRecord();
+        }
+        if (!$record) {
             return;
         }
 
@@ -230,20 +233,6 @@ class ActionsGridFieldItemRequest extends DataExtension
     }
 
     /**
-     * Check if a record can be edited/created/exists
-     * @param DataObject $record
-     * @return bool
-     */
-    protected function checkCan($record)
-    {
-        if (!$record->canEdit() || (!$record->ID && !$record->canCreate())) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
      * @param FieldList $actions
      * @param DataObject $record
      * @return void
@@ -319,7 +308,10 @@ class ActionsGridFieldItemRequest extends DataExtension
      */
     public function addSaveNextAndPrevious(FieldList $actions, DataObject $record)
     {
-        if (!$record->canEdit() || !$record->ID) {
+        if (!$record->canEdit()) {
+            return;
+        }
+        if (!$record->ID) {
             return;
         }
 
@@ -367,7 +359,10 @@ class ActionsGridFieldItemRequest extends DataExtension
      */
     public function addSaveAndClose(FieldList $actions, DataObject $record)
     {
-        if (!$this->checkCan($record)) {
+        if (!$record->canEdit()) {
+            return;
+        }
+        if (!$record->ID && !$record->canCreate()) {
             return;
         }
 


### PR DESCRIPTION
I'm suggesting to revert the changes related to the introduced checkCan() method made to `src/ActionsGridFieldItemRequest.php` in https://github.com/lekoala/silverstripe-cms-actions/pull/22/files#diff-b7a004efabbd9cbfe65185f34b596f2aa2af6736d611d4a034b76f7b2e4f42b5R107

Fixes #28 