### PR TITLE
Add missing CMS preview buttons to DataObjects in 4.11+

### DIFF
--- a/templates/SilverStripe/Admin/Includes/LeftAndMain_EditForm.ss
+++ b/templates/SilverStripe/Admin/Includes/LeftAndMain_EditForm.ss
@@ -62,6 +62,14 @@
 				<%t SilverStripe\Admin\LeftAndMain.PreviewButton 'Preview' %> &raquo;
 			</a>
 			<% end_if %>
+            
+			<% if $hasExtraClass('cms-previewable') %>
+				<% if $Actions.last.id == 'Form_ItemEditForm_RightGroup' %>
+					<% include SilverStripe\\Admin\\LeftAndMain_ViewModeSelector SelectID="preview-mode-dropdown-in-content", ExtraClass="ml-0" %>
+				<% else %>
+					<% include SilverStripe\\Admin\\LeftAndMain_ViewModeSelector SelectID="preview-mode-dropdown-in-content", ExtraClass="ml-auto" %>
+				<% end_if %>
+			<% end_if %>
 		</div>
 		<% end_if %>
 	</div>


### PR DESCRIPTION
This adds bits missing from the template in the latest version of Silverstripe:

https://github.com/silverstripe/silverstripe-admin/blob/89ae5a36889a4cade501dd13a5e215f102e6b044/templates/SilverStripe/Admin/Includes/LeftAndMain_EditForm.ss#L58-L64

Spotted this in elemental - after installing this module the edit/preview/split mode options disappeared