### PR TITLE
Modified test so it respects SS5 trailing slash changes

### DIFF
--- a/tests/CmsActionsTest.php
+++ b/tests/CmsActionsTest.php
@@ -241,7 +241,7 @@ class CmsActionsTest extends SapphireTest
 
         // Without an url, we link on the current controller
         $link = $action->getModelLink("testAction");
-        $this->assertEquals('test_controller/testAction/?CustomLink=testAction', $link);
+        $this->assertEquals('test_controller/testAction?CustomLink=testAction', $link);
 
         // in settings
         $controller->getRequest()->setUrl('admin/settings/EditForm/field/MyModel/item/1/edit');


### PR DESCRIPTION
On SS5, almost all tests succeed out of the box. The only one failing is the first test in CmsActionsTest->testGetModelLink(), due to a slash preceding the query string in the assert. The test runs fine in SS4 but fails under SS5 due to the [new trailing slash policy](https://docs.silverstripe.org/en/5/changelogs/5.0.0/#trailing-slash) - calling Link() on the controller in DefaultLink->getControllerLink no longer generates a trailing slash. However the issue is easily fixed by removing the slash from the assert.