### PR TITLE
Allow custom actions for non-DataObject based GridFields

### DIFF
--- a/src/ActionsGridFieldItemRequest.php
+++ b/src/ActionsGridFieldItemRequest.php
@@ -28,7 +28,6 @@ use SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest;
 use ReflectionObject;
 use SilverStripe\Admin\ModelAdmin;
 use SilverStripe\Core\Extension;
-use SilverStripe\ORM\DataObjectInterface;
 use SilverStripe\View\ViewableData;
 
 /**
@@ -536,10 +535,10 @@ class ActionsGridFieldItemRequest extends Extension
 
     /**
      * @param FieldList $actions
-     * @param DataObjectInterface $record
+     * @param ViewableData $record
      * @return void
      */
-    public function addSaveAndClose(FieldList $actions, DataObjectInterface $record)
+    public function addSaveAndClose(FieldList $actions, ViewableData $record)
     {
         if (!$this->checkCan($record)) {
             return;
@@ -567,10 +566,10 @@ class ActionsGridFieldItemRequest extends Extension
     /**
      * New and existing records have different classes
      *
-     * @param DataObjectInterface $record
+     * @param ViewableData $record
      * @return string
      */
-    protected function getBtnClassForRecord(DataObjectInterface $record)
+    protected function getBtnClassForRecord(ViewableData $record)
     {
         if ($record->ID) {
             return 'btn-outline-primary';


### PR DESCRIPTION
[SilverStripe 5 allows GridField to arbitrary data types](https://docs.silverstripe.org/en/5/developer_guides/forms/using_gridfield_with_arbitrary_data/) now, but when was trying to make use of that feature I encountered types mismatches in this package's codes since it required DataObject to be passed.

This pull request attempts to relax those restrictions to let Custom Actions to work with the new SS5 feature.

TODO:
- [x] Change function parameters' classes
- [ ] Fix `forwardActionToRecord()`
- [ ] Add tests
- [ ] Change the docs/readme if needed