### PR TITLE
Fixing issue with Controller not being passed to addXRecord

### DIFF
--- a/src/ActionsGridFieldItemRequest.php
+++ b/src/ActionsGridFieldItemRequest.php
@@ -777,7 +777,7 @@ class ActionsGridFieldItemRequest extends DataExtension
         //@phpstan-ignore-next-line
         if (method_exists($clickedAction, 'getRedirectURL') && $clickedAction->getRedirectURL()) {
             // we probably need a full ui refresh
-            self::addXReload($clickedAction->getRedirectURL());
+            self::addXReload($controller, $clickedAction->getRedirectURL());
             //@phpstan-ignore-next-line
             return $controller->redirect($clickedAction->getRedirectURL());
         }


### PR DESCRIPTION
Adding missing `$controller` variable to `addXReload` called on line `780`, as this was missing, and would cause an error when attempting to perform controller functions on a string when setting redirect url manually. 

---

Separately, I am having issues with this - however it could be CloudFront related and not something that is solvable in this package. Whenever I set `setShouldRefresh` to true on an `Extension` of a dataobject on my stage server, not development server, the controller is returning `null` on `getReferrer()` found in `addXReload` when attempting to set the `X-ControllerURL` header. 

I am however setting all headers to be correctly passed as and the referrer header is properly being attached in all other circumstances, so I'm wondering if it has to do with the controller choice or something similar; but that seems vague. But I'm not sure why this would fail to set this header when not asking for a reload it does pass this header along fine in the request. It was working all fine before my recent SilverStripe 5.3 upgrade and this being upgraded through to 1.7.6 so I'm not sure if there's something else I'm missing (highly likely) such as the controller choice in `getTopLevelController`. However because this works without issue in dev and not stage then I can probably assume that CloudFront is causing some issue here and it's unrelated to your package.

I do also see that `getToplevelController` is not quite the same as it now is in `GridFieldDetailForm_ItemRequest` but this could just be that because it has references to the RequestHandler slightly differently and I'm not fully aware of the choices you made in this function.