### PR TITLE
Drop no-op setAccessible() call deprecated in PHP 8.5

### DIFF
--- a/src/ActionsGridFieldItemRequest.php
+++ b/src/ActionsGridFieldItemRequest.php
@@ -581,7 +581,6 @@ class ActionsGridFieldItemRequest extends Extension
         $this->getOwner()->getStateManager();
         $reflObject = new ReflectionObject($this->getOwner());
         $reflMethod = $reflObject->getMethod('getEditLinkForAdjacentRecord');
-        $reflMethod->setAccessible(true);
 
         try {
             return $reflMethod->invoke($this->getOwner(), $offset);


### PR DESCRIPTION
Calling `ReflectionMethod::setAccessible()` has been a no-op since PHP 8.1 and is deprecated as of PHP 8.5.

Since this module requires at least PHP 8.3, the call can be safely removed.

Fixes #55